### PR TITLE
Fix module path issues and add test helper

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,8 +18,8 @@ import yaml
 import argparse
 from datetime import datetime
 
-# Adicionar src ao path
-sys.path.append(str(Path(__file__).parent / "src"))
+# Adicionar o diretório raiz ao path para permitir imports do pacote src
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from src.core.system_manager import SystemManager
 from src.core.config_manager import ConfigManager

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -10,8 +10,8 @@ import asyncio
 from pathlib import Path
 import shutil
 
-# Adicionar src ao path
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+# Adicionar o diretório raiz ao path para permitir imports do pacote src
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from src.core.logger import get_trading_logger
 
@@ -266,7 +266,7 @@ MAX_DRAWDOWN_PCT=0.15
                 print("  ✅ Arquivo .env já existe")
             
             # Configurar variáveis de ambiente
-            os.environ['PYTHONPATH'] = str(self.project_root / "src")
+            os.environ['PYTHONPATH'] = str(self.project_root)
             
             print("  ✅ Variáveis de ambiente configuradas")
             print()
@@ -497,8 +497,8 @@ Start Script - Inicia o BTC Perpetual Elite Trader
 import sys
 from pathlib import Path
 
-# Adicionar src ao path
-sys.path.insert(0, str(Path(__file__).parent / "src"))
+# Adicionar o diretório raiz ao path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from main import main
 
@@ -526,8 +526,8 @@ Setup Script - Configuração do BTC Perpetual Elite Trader
 import sys
 from pathlib import Path
 
-# Adicionar src ao path
-sys.path.insert(0, str(Path(__file__).parent / "src"))
+# Adicionar o diretório raiz ao path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from scripts.setup import main
 
@@ -554,8 +554,8 @@ import sys
 import asyncio
 from pathlib import Path
 
-# Adicionar src ao path
-sys.path.insert(0, str(Path(__file__).parent / "src"))
+# Adicionar o diretório raiz ao path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from scripts.test_system import main
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -8,8 +8,8 @@ import sys
 import asyncio
 from pathlib import Path
 
-# Adicionar src ao path
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+# Adicionar o diretório raiz ao path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from src.core.configuration_manager import ConfigurationManager
 from src.core.logger import get_trading_logger

--- a/scripts/test_system.py
+++ b/scripts/test_system.py
@@ -10,8 +10,8 @@ import unittest
 from pathlib import Path
 import time
 
-# Adicionar src ao path
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+# Adicionar o diretório raiz ao path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from src.core.configuration_manager import ConfigurationManager
 from src.core.system_manager import SystemManager

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -2,13 +2,18 @@
 Core module - Componentes centrais do sistema
 """
 
-from .system_manager import SystemManager
-from .config_manager import ConfigManager
-from .logger import setup_logging
+"""Inicialização do módulo core."""
 
-__all__ = [
-    'SystemManager',
-    'ConfigManager', 
-    'setup_logging'
-]
+from importlib import import_module
+
+__all__ = ["SystemManager", "ConfigManager", "setup_logging"]
+
+def __getattr__(name):
+    if name == "SystemManager":
+        return import_module(".system_manager", __name__).SystemManager
+    if name == "ConfigManager":
+        return import_module(".config_manager", __name__).ConfigManager
+    if name == "setup_logging":
+        return import_module(".logger", __name__).setup_logging
+    raise AttributeError(f"module {__name__} has no attribute {name}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))


### PR DESCRIPTION
## Summary
- ensure root project directory is added to `sys.path`
- adjust environment variable setup in deploy script
- add helper `conftest.py` so tests import `src` correctly
- lazily import heavy modules in `src.core`

## Testing
- `pytest -q` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_686696167bac832ca0611cca47fa91ff